### PR TITLE
feat(devices): add temperature&humidity sensor and dimmer switch

### DIFF
--- a/back/.editorconfig
+++ b/back/.editorconfig
@@ -1,0 +1,17 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.ts]
+quote_type = single
+ij_typescript_use_double_quotes = false
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/front/src/app/app.component.html
+++ b/front/src/app/app.component.html
@@ -9,6 +9,10 @@
         <app-device-light [device]="device" />
       } @else if (deviceTypes.valve.includes(device.category)) {
         <app-device-valve [device]="device" />
+      } @else if (deviceTypes.temperature.includes(device.category)) {
+        <app-device-temperature [device]="device | asTemperatureDevice" />
+      } @else if (deviceTypes.dimmerSwitch.includes(device.category)) {
+        <app-device-dimmer-switch [device]="device | asDimmerSwitchDevice" />
       } @else {
         <app-device-unknown [device]="device" />
       }

--- a/front/src/app/app.component.ts
+++ b/front/src/app/app.component.ts
@@ -12,6 +12,10 @@ import { DeviceLightComponent } from './shared/device/components/light/light.com
 import { DeviceSocketComponent } from './shared/device/components/socket/socket.component';
 import { DeviceUnknowComponent } from './shared/device/components/unknown/unknown.component';
 import { DeviceValveComponent } from './shared/device/components/valve/valve.component';
+import { DeviceTemperatureComponent } from './shared/device/components/temperature/temperature.component';
+import { AsTemperatureDevicePipe } from './shared/pipes/as-temperature-device.pipe';
+import { DeviceDimmerSwitchComponent } from './shared/device/components/dimmer-switch/dimmer-switch.component';
+import { AsDimmerSwitchDevicePipe } from './shared/pipes/as-dimmer-switch-device.pipe';
 
 @Component({
   selector: 'app-root',
@@ -28,6 +32,10 @@ import { DeviceValveComponent } from './shared/device/components/valve/valve.com
     DeviceSocketComponent,
     DeviceLightComponent,
     DeviceValveComponent,
+    DeviceTemperatureComponent,
+    AsTemperatureDevicePipe,
+    DeviceDimmerSwitchComponent,
+    AsDimmerSwitchDevicePipe,
   ],
 })
 export class AppComponent implements OnInit {

--- a/front/src/app/config.ts
+++ b/front/src/app/config.ts
@@ -11,4 +11,10 @@ export const deviceTypes = {
   valve: [
     'wkf', // thermostatic valve
   ],
+  temperature: [
+    'wsdcg', // temperature and humidity sensor
+  ],
+  dimmerSwitch: [
+    'tgkg', // dimmer switch
+  ],
 };

--- a/front/src/app/shared/api/models/device.model.ts
+++ b/front/src/app/shared/api/models/device.model.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+// TODO: Use this only as a base interface, create more specific interfaces for different device types
 export interface Device {
   id: string;
   name: string;
   category: string;
   online: boolean;
   status: {
-    code: StatusCode;
+    code: StatusCode | string;
     value: any;
   }[];
 }

--- a/front/src/app/shared/api/models/dimmer-switch-device.model.ts
+++ b/front/src/app/shared/api/models/dimmer-switch-device.model.ts
@@ -1,0 +1,51 @@
+import { Device } from './device.model';
+
+export type DimmerSwitchStatus =
+  {
+    code: DimmerSwitchStatusCode.SWITCH_LED_1 | DimmerSwitchStatusCode.SWITCH_LED_2;
+    value: boolean;
+  }
+  | {
+    code: DimmerSwitchStatusCode.BRIGHT_VALUE_1
+    | DimmerSwitchStatusCode.BRIGHTNESS_MIN_1
+    | DimmerSwitchStatusCode.BRIGHTNESS_MAX_1
+    | DimmerSwitchStatusCode.COUNTDOWN_1
+    | DimmerSwitchStatusCode.BRIGHT_VALUE_2
+    | DimmerSwitchStatusCode.BRIGHTNESS_MIN_2
+    | DimmerSwitchStatusCode.BRIGHTNESS_MAX_2
+    | DimmerSwitchStatusCode.COUNTDOWN_2;
+    value: number;
+  }
+  | {
+    code: DimmerSwitchStatusCode.RELAY_STATUS;
+    value: 'on' | 'off' | 'memory';
+  }
+  | {
+    code: DimmerSwitchStatusCode.LIGHT_MODE;
+    value: 'relay' | 'pos';
+  };
+
+export interface DimmerSwitchDevice extends Device {
+  status: DimmerSwitchStatus[];
+}
+
+// https://developer.tuya.com/en/docs/iot/s?id=K9t2a5mn56bdr
+export enum DimmerSwitchStatusCode {
+  SWITCH_LED_1 = 'switch_led_1',
+  BRIGHT_VALUE_1 = 'bright_value_1',
+  BRIGHTNESS_MIN_1 = 'brightness_min_1',
+  BRIGHTNESS_MAX_1 = 'brightness_max_1',
+  COUNTDOWN_1 = 'countdown_1',
+  SWITCH_LED_2 = 'switch_led_2',
+  BRIGHT_VALUE_2 = 'bright_value_2',
+  BRIGHTNESS_MIN_2 = 'brightness_min_2',
+  BRIGHTNESS_MAX_2 = 'brightness_max_2',
+  COUNTDOWN_2 = 'countdown_2',
+  SWITCH_LED_3 = 'switch_led_3',
+  BRIGHT_VALUE_3 = 'bright_value_3',
+  BRIGHTNESS_MIN_3 = 'brightness_min_3',
+  BRIGHTNESS_MAX_3 = 'brightness_max_3',
+  COUNTDOWN_3 = 'countdown_3',
+  RELAY_STATUS = 'relay_status',
+  LIGHT_MODE = 'light_mode',
+}

--- a/front/src/app/shared/api/models/temperature-device.model.ts
+++ b/front/src/app/shared/api/models/temperature-device.model.ts
@@ -1,0 +1,32 @@
+import { Device } from './device.model';
+
+export type TemperatureStatus =
+  {
+    code: TemperatureStatusCode.TEMPERATURE | TemperatureStatusCode.HUMIDITY;
+    value: number;
+  }
+  | {
+    code: TemperatureStatusCode.BATTERY_STATE;
+    value: TemperatureDeviceBatteryState;
+  } | {
+    code: TemperatureStatusCode.TEMP_UNIT_CONVERT;
+    value: string;
+  };
+
+export interface TemperatureDevice extends Device {
+  status: TemperatureStatus[];
+}
+
+// https://developer.tuya.com/en/docs/iot/s?id=K9gf48k1c0sgo
+export enum TemperatureStatusCode {
+  TEMPERATURE = 'va_temperature',
+  HUMIDITY = 'va_humidity',
+  BATTERY_STATE = 'battery_state',
+  TEMP_UNIT_CONVERT = 'temp_unit_convert',
+}
+
+export enum TemperatureDeviceBatteryState {
+  LOW = 'low',
+  MIDDLE = 'middle',
+  HIGH = 'high',
+}

--- a/front/src/app/shared/device/components/device.scss
+++ b/front/src/app/shared/device/components/device.scss
@@ -10,7 +10,7 @@
 }
 
 .device.offline {
-  background: #0b1739;
+  background: #151f3a;
   border: 0.1px solid rgba(255, 255, 255, 0.1);
 }
 

--- a/front/src/app/shared/device/components/dimmer-switch/dimmer-switch.component.html
+++ b/front/src/app/shared/device/components/dimmer-switch/dimmer-switch.component.html
@@ -1,0 +1,58 @@
+<div
+  class="device cursor-pointer p-5"
+  [class.offline]="!device.online"
+>
+  <h2 class="font-semibold uppercase text-sm">
+    {{ device.name }}
+  </h2>
+
+  <div class="flex relative">
+    <div class="text-sm w-5/6">
+      @for (
+        dimmerSwitch of [
+          Switches.SWITCH_1,
+          Switches.SWITCH_2,
+          Switches.SWITCH_3,
+        ];
+        track dimmerSwitch.statusCode
+      ) {
+        @if (switchState(dimmerSwitch) | isNotNullish) {
+          <div class="flex items-center space-x-4 mt-2">
+            <input
+              #ref
+              type="range"
+              min="10"
+              max="1000"
+              class="w-full range-input"
+              [class.disabled]="!switchState(dimmerSwitch)"
+              [disabled]="!switchState(dimmerSwitch)"
+              [value]="switchBrightness(dimmerSwitch)"
+              (change)="changeBrightness(dimmerSwitch, ref.valueAsNumber)"
+            />
+
+            <div class="flex items-center gap-2">
+              <button
+                class="w-8 h-8 cursor-pointer border rounded-lg flex items-center justify-center"
+                [class.turned-on]="switchState(dimmerSwitch)"
+                (click)="toggleLight(dimmerSwitch)"
+              >
+                <span class="material-icons"> adjust </span>
+              </button>
+            </div>
+          </div>
+        }
+      }
+      <!-- Add a bit of space if there's only one switch -->
+      @if (!(switchState(Switches.SWITCH_2) | isNotNullish)) {
+        <div class="flex items-center space-x-4 mt-2">&nbsp;</div>
+      }
+    </div>
+
+    <div class="flex flex-col space-y-3 absolute right-0 bottom-1">
+      @if (!device.online) {
+        <span class="material-icons">cloud_off</span>
+      }
+      <span class="material-icons cursor-pointer">lightbulb</span>
+    </div>
+  </div>
+</div>

--- a/front/src/app/shared/device/components/dimmer-switch/dimmer-switch.component.scss
+++ b/front/src/app/shared/device/components/dimmer-switch/dimmer-switch.component.scss
@@ -1,0 +1,14 @@
+.turned-on {
+  background: linear-gradient(160deg, #ffb12c 0%, #aa6d00 100%);
+}
+
+.disabled {
+  opacity: 0.15;
+}
+
+.range-input {
+  cursor: pointer;
+  &:active {
+    cursor: grab;
+  }
+}

--- a/front/src/app/shared/device/components/dimmer-switch/dimmer-switch.component.ts
+++ b/front/src/app/shared/device/components/dimmer-switch/dimmer-switch.component.ts
@@ -1,0 +1,92 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable no-param-reassign */
+import { Component, Input } from '@angular/core';
+import { DeviceApiService } from '../../../api/services/device-api.service';
+import { getStatus, getStatusIndex } from '../../utils/device.utils';
+import { DimmerSwitchDevice, DimmerSwitchStatusCode } from '../../../api/models/dimmer-switch-device.model';
+import { IsNotNullishPipe } from '../../../pipes/is-not-nullish.pipe';
+
+interface Switch {
+  statusCode: DimmerSwitchStatusCode;
+  brightnessCode: DimmerSwitchStatusCode;
+}
+
+const Switches: Record<'SWITCH_1' | 'SWITCH_2' | 'SWITCH_3', Switch> = {
+  SWITCH_1: {
+    statusCode: DimmerSwitchStatusCode.SWITCH_LED_1,
+    brightnessCode: DimmerSwitchStatusCode.BRIGHT_VALUE_1,
+  },
+  SWITCH_2: {
+    statusCode: DimmerSwitchStatusCode.SWITCH_LED_2,
+    brightnessCode: DimmerSwitchStatusCode.BRIGHT_VALUE_2,
+  },
+  SWITCH_3: {
+    statusCode: DimmerSwitchStatusCode.SWITCH_LED_3,
+    brightnessCode: DimmerSwitchStatusCode.BRIGHT_VALUE_3,
+  },
+};
+
+@Component({
+  selector: 'app-device-dimmer-switch',
+  templateUrl: './dimmer-switch.component.html',
+  styleUrls: [
+    'dimmer-switch.component.scss',
+    '../device.scss',
+  ],
+  standalone: true,
+  providers: [DeviceApiService],
+  imports: [IsNotNullishPipe],
+})
+export class DeviceDimmerSwitchComponent {
+  @Input({ required: true }) device!: DimmerSwitchDevice;
+
+  Switches = Switches;
+
+  constructor(
+    private deviceApiService: DeviceApiService,
+  ) { }
+
+  switchState(dimmerSwitch: Switch): boolean {
+    return getStatus(this.device, dimmerSwitch.statusCode);
+  }
+
+  switchBrightness(dimmerSwitch: Switch): number {
+    return getStatus(this.device, dimmerSwitch.brightnessCode);
+  }
+
+  toggleLight(dimmerSwitch: Switch): void {
+    if (!this.device.online) return;
+
+    const newValue = !this.switchState(dimmerSwitch);
+    this.deviceApiService.setDevice(
+      this.device.id,
+      [
+        {
+          code: dimmerSwitch.statusCode,
+          value: newValue,
+        },
+      ],
+    ).subscribe(() => {
+      const index = getStatusIndex(this.device, dimmerSwitch.statusCode);
+      if (index !== undefined) this.device.status[index].value = newValue;
+    });
+  }
+
+  changeBrightness(dimmerSwitch: Switch, brightnessValue: number): void {
+    if (!this.device.online) return;
+
+    this.deviceApiService.setDevice(
+      this.device.id,
+      [
+        {
+          code: dimmerSwitch.brightnessCode,
+          value: brightnessValue,
+        },
+      ],
+    ).subscribe(() => {
+      const index = getStatusIndex(this.device, dimmerSwitch.brightnessCode);
+      if (index !== undefined) this.device.status[index].value = brightnessValue;
+    });
+  }
+
+}

--- a/front/src/app/shared/device/components/temperature/temperature.component.html
+++ b/front/src/app/shared/device/components/temperature/temperature.component.html
@@ -1,0 +1,48 @@
+<div
+  class="device p-5"
+  [class.offline]="!device.online"
+>
+  <div class="flex items-center justify-between mb-2">
+    <h2 class="font-semibold uppercase text-sm">
+      {{ device.name }}
+    </h2>
+    <div class="battery-status text-left">
+      @switch (batteryState) {
+        @case (TemperatureDeviceBatteryState.LOW) {
+          <span class="material-icons"> battery_2_bar </span>
+        }
+        @case (TemperatureDeviceBatteryState.MIDDLE) {
+          <span class="material-icons"> battery_4_bar </span>
+        }
+        @case (TemperatureDeviceBatteryState.HIGH) {
+          <span class="material-icons"> battery_std </span>
+          High
+        }
+      }
+    </div>
+  </div>
+
+  <div class="flex relative w-full">
+    <div
+      class="text-sm w-full"
+      [class.invisible]="!device.online"
+    >
+      <div class="temperature text-left">
+        <span class="material-icons"> thermostat </span>
+        {{ temperature / 10 }} °{{ tempUnitConvert.toUpperCase() }}
+      </div>
+      <div class="humidity flex items-center justify-between">
+        <div>
+          <span class="material-icons"> water_drop </span>
+          {{ humidity }}%
+        </div>
+        <div class="flex flex-col space-y-3 absolute right-0 bottom-1">
+          @if (!device.online) {
+            <span class="material-icons">cloud_off</span>
+          }
+          <span class="material-icons cursor-pointer">thermostat</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/front/src/app/shared/device/components/temperature/temperature.component.scss
+++ b/front/src/app/shared/device/components/temperature/temperature.component.scss
@@ -1,0 +1,5 @@
+.temperature,
+.humidity {
+  font-size: 2rem;
+  line-height: 1.2;
+}

--- a/front/src/app/shared/device/components/temperature/temperature.component.ts
+++ b/front/src/app/shared/device/components/temperature/temperature.component.ts
@@ -1,0 +1,39 @@
+/* eslint-disable no-param-reassign */
+import { Component, Input } from '@angular/core';
+import { DeviceApiService } from '../../../api/services/device-api.service';
+import { TemperatureDevice, TemperatureDeviceBatteryState, TemperatureStatusCode } from '../../../api/models/temperature-device.model';
+import { getStatus } from '../../utils/device.utils';
+
+@Component({
+  selector: 'app-device-temperature',
+  templateUrl: './temperature.component.html',
+  styleUrls: [
+    './temperature.component.scss',
+    '../device.scss',
+  ],
+  standalone: true,
+  providers: [DeviceApiService],
+})
+export class DeviceTemperatureComponent {
+  @Input({ required: true }) device!: TemperatureDevice;
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  TemperatureDeviceBatteryState = TemperatureDeviceBatteryState;
+
+  get temperature(): number {
+    return getStatus(this.device, TemperatureStatusCode.TEMPERATURE);
+  }
+
+  get humidity(): number {
+    return getStatus(this.device, TemperatureStatusCode.HUMIDITY);
+  }
+
+  get batteryState(): string {
+    return getStatus(this.device, TemperatureStatusCode.BATTERY_STATE);
+  }
+
+  get tempUnitConvert(): string {
+    return getStatus(this.device, TemperatureStatusCode.TEMP_UNIT_CONVERT);
+  }
+
+}

--- a/front/src/app/shared/device/components/unknown/unknown.component.html
+++ b/front/src/app/shared/device/components/unknown/unknown.component.html
@@ -1,4 +1,7 @@
-<div class="device p-5">
+<div
+  class="device p-5"
+  [class.offline]="!device.online"
+>
   <h2 class="font-semibold uppercase text-sm">
     {{ device.name }}
   </h2>

--- a/front/src/app/shared/device/utils/device.utils.ts
+++ b/front/src/app/shared/device/utils/device.utils.ts
@@ -1,10 +1,14 @@
 import { Device, StatusCode } from '../../api/models/device.model';
+import { DimmerSwitchStatusCode } from '../../api/models/dimmer-switch-device.model';
+import { TemperatureStatusCode } from '../../api/models/temperature-device.model';
+
+type DeviceStatusCode = StatusCode | TemperatureStatusCode | DimmerSwitchStatusCode;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function getStatus(device: Device, statusCode: StatusCode): any {
+export function getStatus(device: Device, statusCode: DeviceStatusCode): any {
   return device.status?.find((status) => status.code === statusCode)?.value;
 }
 
-export function getStatusIndex(device: Device, statusCode: StatusCode): number | undefined {
+export function getStatusIndex(device: Device, statusCode: DeviceStatusCode): number | undefined {
   return device.status?.findIndex((status) => status.code === statusCode);
 }

--- a/front/src/app/shared/pipes/as-dimmer-switch-device.pipe.ts
+++ b/front/src/app/shared/pipes/as-dimmer-switch-device.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { Device } from '../api/models/device.model';
+import { DimmerSwitchDevice } from '../api/models/dimmer-switch-device.model';
+
+@Pipe({
+  name: 'asDimmerSwitchDevice',
+  pure: true,
+  standalone: true,
+})
+export class AsDimmerSwitchDevicePipe implements PipeTransform {
+
+  transform(device: Device): DimmerSwitchDevice {
+    return device as DimmerSwitchDevice;
+  }
+
+}

--- a/front/src/app/shared/pipes/as-temperature-device.pipe.ts
+++ b/front/src/app/shared/pipes/as-temperature-device.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { TemperatureDevice } from '../api/models/temperature-device.model';
+import { Device } from '../api/models/device.model';
+
+@Pipe({
+  name: 'asTemperatureDevice',
+  pure: true,
+  standalone: true,
+})
+export class AsTemperatureDevicePipe implements PipeTransform {
+
+  transform(device: Device): TemperatureDevice {
+    return device as TemperatureDevice;
+  }
+
+}

--- a/front/src/app/shared/pipes/is-not-nullish.pipe.ts
+++ b/front/src/app/shared/pipes/is-not-nullish.pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { isNotNullish } from '../util/is-nullish';
+
+@Pipe({
+  name: 'isNotNullish',
+  pure: true,
+  standalone: true,
+})
+export class IsNotNullishPipe implements PipeTransform {
+
+  transform<T>(val: T): val is T {
+    return isNotNullish(val);
+  }
+
+}

--- a/front/src/app/shared/util/is-nullish.ts
+++ b/front/src/app/shared/util/is-nullish.ts
@@ -1,0 +1,4 @@
+/* eslint-disable no-restricted-syntax */
+export const isNotNullish = <T>(val: T | undefined | null): val is T => val !== null && val !== undefined;
+
+export const isNullish = <T>(val: T | undefined | null): val is undefined | null => val === null || val === undefined;


### PR DESCRIPTION
Hi,

I just discovered your project and I went on and added support for temperature&humidity sensor and dimmer switch.
I tested it with my devices. I don't own a 3-switch dimmer switch (only a 2-switch version), but _theoretically_ that also should work, based on Tuya's documentation.

Changelog:
- Added support for [Temperature & Humidity sensor](https://developer.tuya.com/en/docs/iot/s?id=K9gf48k1c0sgo)
  - displaying the temperature, the humidity and the battery status
- Added support for [Dimmer Switch](https://developer.tuya.com/en/docs/iot/s?id=K9t2a5mn56bdr)
  - displaying a brightness range input and a switch
  - only displaying existing switches (if your device only has 1 switches, then only 1 switch is displayed, but if it has 2 or 3 then those are also displayed)
  - range selector is disabled when the light is turned off
- Changed the background of the offline devices (previously it was the same color as online devices)

For these new devices, I added more specific interfaces & enums, I also added a TODO note to the `Device` interface - I think it should be somehow treated as abstract and each device should be extended from this - that's what I did with the new ones. I haven't modified the already existing ones as I didn't want to make too many changes.

<img width="1415" height="537" alt="image" src="https://github.com/user-attachments/assets/4facb31d-894f-4541-b21d-5574fe311955" />

P.S. I really like your code and your coding style, it was really nice to work with it!
